### PR TITLE
fix(release): use GCC toolchains instead of zig/musl for CGO builds

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version-file: go.mod
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,8 @@ jobs:
           go-version: stable
       # More assembly might be required: Docker logins, GPG, etc.
       # It all depends on your needs.
-      - uses: mlugg/setup-zig@v2
       - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y g++
+        run: sudo apt-get update && sudo apt-get install -y g++ gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,16 +31,14 @@ builds:
       - -trimpath
     env:
       - CGO_ENABLED=1
+      # The duckdb-go-bindings static libraries are built with GCC against
+      # glibc/libstdc++, so they must be linked with a GCC toolchain (zig's
+      # libc++ and musl cannot resolve their symbols): native gcc for amd64,
+      # the aarch64-linux-gnu cross toolchain for arm64.
       - >-
-        {{- if eq .Os "linux" }}
-          {{- if eq .Arch "amd64" }}CC=zig c -target x86_64-linux-musl{{- end }}
-          {{- if eq .Arch "arm64"}}CC=zig c -target aarch64-linux-musl{{- end }}
-        {{- end }}
+        {{- if eq .Arch "arm64" }}CC=aarch64-linux-gnu-gcc{{- else }}CC=gcc{{- end }}
       - >-
-        {{- if eq .Os "linux" }}
-          {{- if eq .Arch "amd64" }}CC=zig c++ -target x86_64-linux-musl{{- end }}
-          {{- if eq .Arch "arm64"}}CC=zig c++ -target aarch64-linux-musl{{- end }}
-        {{- end }}
+        {{- if eq .Arch "arm64" }}CXX=aarch64-linux-gnu-g++{{- else }}CXX=g++{{- end }}
 archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.


### PR DESCRIPTION
Release builds have never succeeded — tags v0.1.8 and v0.1.9 exist with no published releases. The goreleaser snapshot check added in 1f5aed1 surfaced why.

## Root cause
`.goreleaser.yaml` cross-compiled with `zig c -target x86_64-linux-musl`, but the `duckdb-go-bindings` static libraries are built with GCC against glibc/libstdc++:
- musl has no `malloc_trim` or `execinfo` (`backtrace`/`backtrace_symbols`)
- zig links its own libc++, which cannot resolve GCC's `__cxx11` libstdc++ ABI symbols

That combination can never link. There was also a typo: both `env` entries set `CC=` — the second (`zig c++`) was presumably meant to be `CXX=`.

## Fix
- linux/amd64: build with the runner's native `gcc`/`g++`
- linux/arm64: build with the `aarch64-linux-gnu` GCC cross toolchain
- release.yml: install `gcc-aarch64-linux-gnu g++-aarch64-linux-gnu` instead of setting up zig

The goreleaser check on this PR runs `release --snapshot`, i.e. a full real build of both architectures — if it's green, the release pipeline works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)